### PR TITLE
log most recent resize time in main.js

### DIFF
--- a/views/js/main.js
+++ b/views/js/main.js
@@ -463,7 +463,7 @@ var resizePizzas = function(size) {
   window.performance.mark("mark_end_resize");
   window.performance.measure("measure_pizza_resize", "mark_start_resize", "mark_end_resize");
   var timeToResize = window.performance.getEntriesByName("measure_pizza_resize");
-  console.log("Time to resize pizzas: " + timeToResize[0].duration + "ms");
+  console.log("Time to resize pizzas: " + timeToResize[timeToResize.length-1].duration + "ms");
 };
 
 window.performance.mark("mark_start_generating"); // collect timing data


### PR DESCRIPTION
I think there is a bug in the project code for timing of resizing pizzas. Line 466 says:
console.log("Time to resize pizzas: " + timeToResize[0].duration + "ms");

which works fine for the first resize event, but additional resizes go to the end of the timeToResize array, not the beginning. That is why all resizes give the same duration, which would be rather shocking if it were true. The code should probably be something like:

console.log("Time to resize pizzas: " + timeToResize[timeToResize.length-1].duration + "ms");
